### PR TITLE
Refactor package.json to reference types

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+.github
 node_modules/
 .DS_STORE
 .npmignore
@@ -5,3 +6,6 @@ node_modules/
 .prettierignore
 .prettierrc.cjs
 src/
+*.js.map
+.prettierignore
+.prettierrc.cjs

--- a/package.json
+++ b/package.json
@@ -15,22 +15,30 @@
   ],
   "type": "module",
   "scripts": {
-    "build": "microbundle",
+    "build": "microbundle && npm run build:cjs-types && npm run build:mjs-types",
+    "build:cjs-types": "tsc --module commonjs --emitDeclarationOnly --declaration --outDir dist/cjs",
+    "build:mjs-types": "tsc --module esnext --emitDeclarationOnly --declaration --outDir dist/mjs",
     "dev": "microbundle watch",
     "format": "npx prettier --write .",
     "lint": "npx prettier --check .",
     "test": "tsc --noEmit",
     "prepublishOnly": "npm run format && npm run build"
   },
-  "source": "src/index.ts",
   "exports": {
-    "require": "./dist/index.cjs",
-    "default": "./dist/index.modern.js"
+    ".": {
+      "import": {
+        "types": "./dist/mjs/index.d.ts",
+        "default": "./dist/index.modern.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    }
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.module.js",
-  "unpkg": "./dist/index.umd.js",
-  "types": "./dist/src/index.d.ts",
+  "types": "./dist/mjs/index.d.ts",
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/node": "^20.10.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,13 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "module": "commonjs",
+    "module": "esnext",
     "moduleResolution": "node",
     "outDir": "dist",
-    "rootDir": "",
+    "rootDir": "src",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
-    "declaration": true,
-    "declarationDir": "./dist"
-  },
-  "include": ["src"]
+    "sourceMap": false
+  }
 }


### PR DESCRIPTION
It also compiles separate cjs types for the cjs version.
Ref: https://stackoverflow.com/a/77566206

Personally, I think cjs isn't worth it, but there maybe still exists some legacy application that uses cjs.